### PR TITLE
Missing dash in id attribute between form name and id

### DIFF
--- a/grappelli_nested/templates/admin/edit_inline/stacked.html
+++ b/grappelli_nested/templates/admin/edit_inline/stacked.html
@@ -16,7 +16,7 @@
     <div class="grp-items">
         {% for inline_admin_form in recursive_formset %}
             <!-- element -->
-            <div class="grp-module {{ recursive_formset.opts.inline_classes|join:" "|default:"grp-collapse grp-closed" }}{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} grp-empty-form{% endif %}" id="{{ inline_admin_formset.formset.prefix }}{% if forloop.last %}-empty{% else %}{{ forloop.counter0 }}{% endif %}">
+            <div class="grp-module {{ recursive_formset.opts.inline_classes|join:" "|default:"grp-collapse grp-closed" }}{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} grp-empty-form{% endif %}" id="{{ inline_admin_formset.formset.prefix }}{% if forloop.last %}-empty{% else %}-{{ forloop.counter0 }}{% endif %}">
                 <h3 class="grp-collapse-handler">{{ recursive_formset.opts.verbose_name|title }}&nbsp;&nbsp;{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% endif %}</h3>
                 <ul class="grp-tools">
                     {% if inline_admin_form.show_url %}<li><a href="{% url 'admin:view_on_site' inline_admin_form.original_content_type_id inline_admin_form.original.pk %}" class="grp-icon grp-viewsite-link" title="{% trans 'View on Site' %}" target="_blank"></a></li>{% endif %}

--- a/grappelli_nested/templates/admin/edit_inline/tabular.html
+++ b/grappelli_nested/templates/admin/edit_inline/tabular.html
@@ -25,7 +25,7 @@
         {% with recursive_formset.opts.sortable_field_name|default:"" as sortable_field_name %}
         {% for inline_admin_form in recursive_formset|formsetsort:sortable_field_name %}
 
-            <div class="grp-module grp-tbody {% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} grp-empty-form{% endif %}" id="{{ recursive_formset.formset.prefix }}{% if not forloop.last %}{{ forloop.counter0 }}{% else %}-empty{% endif %}">
+            <div class="grp-module grp-tbody {% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} grp-empty-form{% endif %}" id="{{ recursive_formset.formset.prefix }}{% if not forloop.last %}-{{ forloop.counter0 }}{% else %}-empty{% endif %}">
                 {% if inline_admin_form.form.non_field_errors %}
                     {{ inline_admin_form.form.non_field_errors }}
                 {% endif %}


### PR DESCRIPTION
Id is set to `details0`, `details1` instead of `deatails-0`, `details-1`. This cause problems in JS, when using form id to construct field queries and names which were constructed properly: `details-1-field_name`, `details-1-nested-0-field_name`
