### PR TITLE
Deprecation warning fix and handle AttributeError in NestedFormMixin

### DIFF
--- a/grappelli_nested/admin.py
+++ b/grappelli_nested/admin.py
@@ -78,11 +78,11 @@ class NestedModelAdmin(ModelAdmin):
                                     save_as_new="_saveasnew" in request.POST,
                                     instance=form.instance,
                                     prefix=prefix,
-                                    queryset=nested_inline.queryset(request)
+                                    queryset=nested_inline.get_queryset(request)
                                 )
                 else:
                     nested_formset = InlineFormSet(instance=form.instance,
-                                                   prefix=prefix, queryset=nested_inline.queryset(request))
+                                                   prefix=prefix, queryset=nested_inline.get_queryset(request))
                 nested_formsets.append(nested_formset)
                 if nested_inline.inlines:
                     self.add_nested_inline_formsets(request, nested_inline, nested_formset, depth=depth+1)
@@ -186,7 +186,7 @@ class NestedModelAdmin(ModelAdmin):
                 formset = FormSet(data=request.POST, files=request.FILES,
                                   instance=new_object,
                                   save_as_new="_saveasnew" in request.POST,
-                                  prefix=prefix, queryset=inline.queryset(request))
+                                  prefix=prefix, queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -214,7 +214,7 @@ class NestedModelAdmin(ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=self.model(), prefix=prefix,
-                                  queryset=inline.queryset(request))
+                                  queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)
@@ -311,7 +311,7 @@ class NestedModelAdmin(ModelAdmin):
                 if prefixes[prefix] != 1 or not prefix:
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(instance=obj, prefix=prefix,
-                                  queryset=inline.queryset(request))
+                                  queryset=inline.get_queryset(request))
                 formsets.append(formset)
                 if inline.inlines:
                     self.add_nested_inline_formsets(request, inline, formset)

--- a/grappelli_nested/forms.py
+++ b/grappelli_nested/forms.py
@@ -32,8 +32,12 @@ class NestedFormMixin(object):
         """
         if self.instance.pk is None:
             nested_formsets = getattr(self, 'nested_formsets', ())
-            nested_has_changed = any(
+            try:
+            	nested_has_changed = any(
                 (formset.has_changed() for formset in nested_formsets))
+            except AttributeError:
+                # catch an error if a give form has no has_changed setting
+                nested_has_changed = True
         else:
             nested_has_changed = False
         return (super(NestedFormMixin, self).has_changed() or

--- a/grappelli_nested/forms.py
+++ b/grappelli_nested/forms.py
@@ -32,8 +32,12 @@ class NestedFormMixin(object):
         """
         if self.instance.pk is None:
             nested_formsets = getattr(self, 'nested_formsets', ())
+            try:
             nested_has_changed = any(
                 (formset.has_changed() for formset in nested_formsets))
+            except AttributeError:
+                # catch an error if a give form has no has_changed setting
+                nested_has_changed = True
         else:
             nested_has_changed = False
         return (super(NestedFormMixin, self).has_changed() or


### PR DESCRIPTION
1. queryset was deprecated and replaced with get_queryset: https://docs.djangoproject.com/en/1.8/releases/1.6/
2. Added a try block around has_changed to handle cases where a form may not have a has_changed defined.  AdminForm and its descedants are one such instance.

```
AttributeError at /_admin/...
'InlineAdminFormSet' object has no attribute 'has_changed'
Request Method: POST
```
